### PR TITLE
i/101: Editor config defined in the component should not be mutable

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -53,13 +53,15 @@ export default {
 	},
 
 	mounted() {
+		// Clone the config first so it never gets mutated (across multiple editor instances).
+		// https://github.com/ckeditor/ckeditor5-vue/issues/101
+		const editorConfig = Object.assign( {}, this.config );
+
 		if ( this.value ) {
-			Object.assign( this.config, {
-				initialData: this.value
-			} );
+			editorConfig.initialData = this.value;
 		}
 
-		this.editor.create( this.$el, this.config )
+		this.editor.create( this.$el, editorConfig )
 			.then( editor => {
 				// Save the reference to the instance for further use.
 				this.instance = editor;

--- a/tests/ckeditor.js
+++ b/tests/ckeditor.js
@@ -190,6 +190,53 @@ describe( 'CKEditor Component', () => {
 					done();
 				} );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5-vue/issues/101
+			it( 'should not be mutated', done => {
+				const createStub = sandbox.stub( MockEditor, 'create' ).resolves( new MockEditor() );
+
+				const ParentComponent = {
+					data() {
+						return {
+							editor: MockEditor,
+							editorConfig: {
+								foo: 'bar'
+							},
+							editorFooData: 'foo',
+							editorBarData: 'bar',
+							editorBazData: 'baz'
+						};
+					},
+					template: `
+						<div>
+							<ckeditor :editor="editor" tag-name="textarea" v-model="editorFooData" :config="editorConfig">foo</ckeditor>
+							<ckeditor :editor="editor" tag-name="textarea" v-model="editorBarData" :config="editorConfig">bar</ckeditor>
+							<ckeditor :editor="editor" tag-name="textarea" v-model="editorBazData" :config="editorConfig">baz</ckeditor>
+						</div>
+					`
+				};
+
+				const { vm } = mount( ParentComponent, {
+					stubs: {
+						ckeditor: CKEditorComponent
+					}
+				} );
+
+				Vue.nextTick( () => {
+					const fooEditorConfig = createStub.firstCall.args[ 1 ];
+					const barEditorConfig = createStub.secondCall.args[ 1 ];
+					const bazEditorConfig = createStub.thirdCall.args[ 1 ];
+
+					expect( fooEditorConfig ).to.not.equal( barEditorConfig );
+					expect( fooEditorConfig ).to.not.equal( bazEditorConfig );
+					expect( barEditorConfig ).to.not.equal( bazEditorConfig );
+
+					expect( vm.editorConfig.initialData ).to.be.undefined;
+
+					wrapper.destroy();
+					done();
+				} );
+			} );
 		} );
 
 		it( '#instance should be defined', done => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Editor config defined in the component should not be mutable. Closes #101.
