### PR TITLE
Fixed: Cannot set property 'isReadOnly' of null

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -121,7 +121,9 @@ export default {
 
 		// Synchronize changes of #disabled.
 		disabled( val ) {
-			this.instance.isReadOnly = val;
+			if (this.instance) {	
+				this.instance.isReadOnly = val;
+			}
 		}
 	},
 


### PR DESCRIPTION
When the prop `disabled` is mutated AFTER the component has mounted, but BEFORE `this.editor.create` is resolved, this results in an error "TypeError: Cannot set property 'isReadOnly' of null". Checking if the instance is successfully initialized prevents this error.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
