### PR TITLE
New 'changing' event that may prevent data loss

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -137,12 +137,24 @@ export default {
 				// The compatibility with the v-model and general Vue.js concept of input–like components.
 				this.$emit( 'input', data, evt, editor );
 			};
-
+			
 			// Debounce emitting the #input event. When data is huge, instance#getData()
 			// takes a lot of time to execute on every single key press and ruins the UX.
 			//
 			// See: https://github.com/ckeditor/ckeditor5-vue/issues/42
-			editor.model.document.on( 'change:data', debounce( emitInputEvent, INPUT_EVENT_DEBOUNCE_WAIT ) );
+			//
+			// As #input event is debouced and processing data may take some time,
+			// there could be a situation when user changed huge data and imediatenly push some SAVE button. 
+			// But real data is not updated yet.
+			// The #changing event if fired right after change.
+			// You can combine 'value' property, #changing and #input event to be sure that data is updated.
+			const debouncedInput = debounce(emitInputEvent, INPUT_EVENT_DEBOUNCE_WAIT)
+			editor.model.document.on('change:data', (evt) => {
+				this.$emit('changing', evt, editor);
+				debouncedInput(evt);
+			});
+			
+
 
 			editor.editing.view.document.on( 'focus', evt => {
 				this.$emit( 'focus', evt, editor );


### PR DESCRIPTION
Other: Additional `changing` event right after data is changed by user.

This event is firing immediately after user changed something in editor. It happens without 300ms delay that `input` event has. Event could be used to disable some Save button and enable it again on `input` event


Sample usage:
```html
<ckeditor :config="config" :editor="editor" :value="initialHtmlContent"
          @changing="disableSaveButton"
          @input="updateDataAndEnableSaveButton" />
```

PS: I think some additional autotests have to be written