### PR TITLE
Updated required node version to 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: node_js
 services:
 - xvfb
 node_js:
-- '12'
+- '14'
 cache:
 - node_modules
 install:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-cli": "^3.1.0"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=14.0.0",
     "npm": ">=5.7.1"
   },
   "scripts": {


### PR DESCRIPTION
Other: Updated the required version of Node.js to 14. See ckeditor/ckeditor5#10972.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `14.0.0` due to the end of LTS.