### PR TITLE
fix issue for vue 3.2.x

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -67,8 +67,6 @@ export default {
 		return {
 			// Don't define it in #props because it produces a warning.
 			// https://v3.vuejs.org/guide/component-props.html#one-way-data-flow
-			instance: null,
-
 			lastEditorData: {
 				type: String,
 				default: ''


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

from vue 3.2.x - every property on the data becomes reactive() and not ref(), and since that version - every getter from the reactive proxy returns a reactive proxy of the internal property.
because of that, using methods under the instance is throwing errors because the "this" context is the proxy and not the instance.

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
