### PR TITLE
Fix: Update types to allow any type of editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@babel/core": "^7.17.7",
         "@ckeditor/ckeditor5-build-classic": "^37.0.0-alpha.2",
+        "@ckeditor/ckeditor5-core": "^37.0.0-alpha.2",
         "@ckeditor/ckeditor5-dev-bump-year": "^32.0.1",
         "@ckeditor/ckeditor5-dev-ci": "^32.0.1",
         "@ckeditor/ckeditor5-dev-release-tools": "^32.0.1",
@@ -50,9 +51,6 @@
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=5.7.1"
-      },
-      "peerDependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^37.0.0-alpha.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.7",
     "@ckeditor/ckeditor5-build-classic": "^37.0.0-alpha.2",
+    "@ckeditor/ckeditor5-core": "^37.0.0-alpha.2",
     "@ckeditor/ckeditor5-dev-bump-year": "^32.0.1",
     "@ckeditor/ckeditor5-dev-ci": "^32.0.1",
     "@ckeditor/ckeditor5-dev-release-tools": "^32.0.1",
@@ -56,9 +57,6 @@
     "vue": "^3.2.31",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0"
-  },
-  "peerDependencies": {
-    "@ckeditor/ckeditor5-build-classic": "^37.0.0-alpha.2"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/src/ckeditor.ts
+++ b/src/ckeditor.ts
@@ -7,14 +7,15 @@
 
 import { defineComponent, h, markRaw, type PropType } from 'vue';
 import { debounce } from 'lodash-es';
-import type { EditorConfig } from '@ckeditor/ckeditor5-core';
-import type ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import type { Editor, DataApi, EditorConfig } from '@ckeditor/ckeditor5-core';
 
 const SAMPLE_READ_ONLY_LOCK_ID = 'Integration Sample';
 const INPUT_EVENT_DEBOUNCE_WAIT = 300;
 
+type EditorInstance = Editor & DataApi;
+
 export interface CKEditorComponentData {
-	instance: ClassicEditor | null;
+	instance: EditorInstance | null;
 	lastEditorData: string | null;
 }
 
@@ -49,7 +50,7 @@ export default defineComponent( {
 
 	props: {
 		editor: {
-			type: Function as unknown as PropType<typeof ClassicEditor>,
+			type: Function as unknown as PropType<{ create( ...args: any ): Promise<EditorInstance> }>,
 			required: true
 		},
 		config: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Update types to allow any type of editor. Closes https://github.com/ckeditor/ckeditor5/issues/13543
