### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "semver": "^7"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18 when developing the repository. See https://github.com/ckeditor/ckeditor5/issues/14924.