### PR TITLE
Fix: Fix component prop and event types.

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "../src/plugin.ts"
+    ]
+  },
+  "include": [
+    "**/*"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "build": "vite build && vue-tsc --declaration --emitDeclarationOnly",
     "test": "vitest run --coverage",
     "test:watch": "vitest --ui --watch",
-    "lint": "eslint \"{demo,src,tests}/**/*\"",
+    "lint": "eslint \"{demo,src,tests}/**/*.{ts,vue}\"",
     "postinstall": "node ./scripts/postinstall.js",
     "changelog": "node ./scripts/changelog.js",
     "release:prepare-packages": "node ./scripts/preparepackages.js",

--- a/src/ckeditor.vue
+++ b/src/ckeditor.vue
@@ -19,8 +19,9 @@ import {
 	onBeforeUnmount
 } from 'vue';
 import type { Editor, EditorConfig, EventInfo } from 'ckeditor5';
+import type { Props, ExtractEditorType } from './types.js';
 
-type EditorType = TEditor extends { create( ...args: any[] ): Promise<infer E> } ? E : never;
+type EditorType = ExtractEditorType<TEditor>;
 
 defineOptions( {
 	name: 'CKEditor'
@@ -28,13 +29,7 @@ defineOptions( {
 
 const model = defineModel( 'modelValue', { type: String, default: '' } );
 
-const props = withDefaults( defineProps<{
-	editor: TEditor;
-	config?: EditorConfig;
-	tagName?: string;
-	disabled?: boolean;
-	disableTwoWayDataBinding?: boolean;
-}>(), {
+const props = withDefaults( defineProps<Props<TEditor>>(), {
 	config: () => ( {} ),
 	tagName: 'div',
 	disabled: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { EditorConfig } from 'ckeditor5';
+
+/**
+ * This file contains types for the CKEditor 5 Vue component.
+ * These types were moved to a separate file, because the `vue-tsc`
+ * package couldn't generate the correct types for the component
+ * when the types were in the component file. This is a workaround
+ * that may be fixed in the next versions of `vue-tsc`.
+ */
+
+/**
+ * The props accepted by the `<ckeditor>` component.
+ */
+export interface Props<TEditor> {
+	editor: TEditor;
+	config?: EditorConfig;
+	tagName?: string;
+	disabled?: boolean;
+	disableTwoWayDataBinding?: boolean;
+}
+
+/**
+ * The editor type extracted from the editor instance type.
+ */
+export type ExtractEditorType<TEditor> = TEditor extends { create( ...args: Array<any> ): Promise<infer E> }
+	? E
+	: never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,7 @@
     "declaration": true,
     "declarationDir": "./dist"
   },
-  "include": ["src/plugin.ts"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fix the component properties and event types.

Internal: Add `tsconfig.json` to the demo.

Internal: Lint only the `.ts` and `.vue` files.

---

### Additional information

For the `7.0.0-alpha.0` release, we migrated the component to a Single File Component (SFC) format. Unfortunately, for whatever reason, the resulting `.d.ts` file doesn't contain the correct types for props and events. This PR fixes them by moving the types and interfaces to a separate file.
