### PR TITLE
Improve typing `useCKEditorCloud` to make it more narrow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ commands:
           name: Prepare environment variables
           command: |
             #!/bin/bash
-            
+
             # Non-secret environment variables needed for the pipeline scripts.
             CKE5_GITHUB_ORGANIZATION="ckeditor"
             CKE5_GITHUB_REPOSITORY="ckeditor5-vue"
             CKE5_CIRCLE_APPROVAL_JOB_NAME="release_approval"
             CKE5_GITHUB_RELEASE_BRANCH="master"
-            
+
             echo export CKE5_CIRCLE_APPROVAL_JOB_NAME=$CKE5_CIRCLE_APPROVAL_JOB_NAME >> $BASH_ENV
             echo export CKE5_GITHUB_RELEASE_BRANCH=$CKE5_GITHUB_RELEASE_BRANCH >> $BASH_ENV
             echo export CKE5_GITHUB_ORGANIZATION=$CKE5_GITHUB_ORGANIZATION >> $BASH_ENV
@@ -117,6 +117,9 @@ jobs:
       - run:
           name: Build demo app
           command: yarn run build
+      - run:
+          name: Check types of tests
+          command: yarn run test:check:types
       - run:
          name: Verify the code coverage
          command: |
@@ -205,13 +208,13 @@ jobs:
           name: Verify if a releaser triggered the job
           command: |
             #!/bin/bash
-            
+
             # Do not fail if the Node script ends with non-zero exit code.
             set +e
-    
+
             yarn ckeditor5-dev-ci-is-job-triggered-by-member
             EXIT_CODE=$( echo $? )
-    
+
             if [ ${EXIT_CODE} -ne 0 ];
             then
               echo "Aborting the release due to failed verification of the approver (no rights to release)."

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "@ckeditor/ckeditor5-integrations-common": "^1.0.0"
+    "@ckeditor/ckeditor5-integrations-common": "^2.0.0"
   },
   "peerDependencies": {
     "ckeditor5": ">=42.0.0 || ^0.0.0-nightly",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "build": "vite build && vue-tsc --declaration --emitDeclarationOnly",
     "test": "vitest run --coverage",
     "test:watch": "vitest --ui --watch",
+    "test:check:types": "tsc --noEmit -p ./tests/tsconfig.json",
     "lint": "eslint \"{demos,src,tests}/**/*.{ts,vue}\"",
     "postinstall": "node ./scripts/postinstall.js",
     "changelog": "node ./scripts/changelog.js",

--- a/src/useCKEditorCloud.ts
+++ b/src/useCKEditorCloud.ts
@@ -8,7 +8,6 @@ import { useAsync, type AsyncComposableResult } from './composables/useAsync';
 
 import {
 	loadCKEditorCloud,
-	type CdnPluginsPacks,
 	type CKEditorCloudConfig,
 	type CKEditorCloudResult
 } from '@ckeditor/ckeditor5-integrations-common';
@@ -18,7 +17,7 @@ import {
  *
  * @param config The configuration of the CKEditor Cloud services.
  * @returns The result of the loaded CKEditor Cloud services.
- * @template A The type of the additional resources to load.
+ * @template Config The type of the CKEditor Cloud configuration.
  * @experimental
  * @example
  * ```ts
@@ -35,11 +34,11 @@ import {
  * 	// ..
  * }
  */
-export default function useCKEditorCloud<A extends CdnPluginsPacks>(
-	config: MaybeRefOrGetter<CKEditorCloudConfig<A>>
-): AsyncComposableResult<CKEditorCloudResult<A>> {
+export default function useCKEditorCloud<Config extends CKEditorCloudConfig>(
+	config: MaybeRefOrGetter<Config>
+): AsyncComposableResult<CKEditorCloudResult<Config>> {
 	return useAsync(
-		(): Promise<CKEditorCloudResult<A>> => loadCKEditorCloud(
+		(): Promise<CKEditorCloudResult<Config>> => loadCKEditorCloud(
 			toValue( config )
 		)
 	);

--- a/tests/ckeditor.test.ts
+++ b/tests/ckeditor.test.ts
@@ -6,7 +6,7 @@
 import { nextTick } from 'vue';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { Ckeditor } from '../src/plugin.ts';
+import { Ckeditor } from '../src/plugin';
 import {
 	MockEditor,
 	ModelDocument,

--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+declare module '*.vue' {
+	import type { DefineComponent } from 'vue';
+
+	const Component: DefineComponent<object, object, any>;
+
+	export default Component;
+  }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"emitDeclarationOnly": false,
+		"noImplicitAny": false
+	},
+	"include": [
+		"./",
+		"../src"
+	]
+}

--- a/tests/useCKEditorCloud.test.ts
+++ b/tests/useCKEditorCloud.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import { beforeEach, describe, it, vi, expect } from 'vitest';
+import { beforeEach, describe, it, vi, expect, expectTypeOf } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { ref } from 'vue';
 
@@ -51,6 +51,82 @@ describe( 'useCKEditorCloud', () => {
 		await vi.waitFor( () => {
 			expect( data.value?.CKEditor ).toBeDefined();
 			expect( data.value?.CKEditorPremiumFeatures ).toBeDefined();
+		} );
+	} );
+
+	describe( 'typings', () => {
+		it( 'should return non-nullable premium features entry type if premium is enabled', async () => {
+			const { data } = useCKEditorCloud( {
+				version: '43.0.0',
+				premium: true
+			} );
+			await vi.waitFor( () => {
+				expect( data.value?.CKEditor ).toBeDefined();
+			} );
+
+			if ( data.value ) {
+				expectTypeOf( data.value?.CKEditorPremiumFeatures ).not.toBeNullable();
+			}
+		} );
+
+		it( 'should return nullable premium features entry type if premium is not passed', async () => {
+			const { data } = useCKEditorCloud( {
+				version: '43.0.0'
+			} );
+
+			await vi.waitFor( () => {
+				expect( data.value?.CKEditor ).toBeDefined();
+			} );
+
+			if ( data.value ) {
+				expectTypeOf( data.value.CKEditorPremiumFeatures ).toBeNullable();
+			}
+		} );
+
+		it( 'should return nullable premium features entry type if premium is false', async () => {
+			const { data } = useCKEditorCloud( {
+				version: '43.0.0',
+				premium: false
+			} );
+
+			await vi.waitFor( () => {
+				expect( data.value?.CKEditor ).toBeDefined();
+			} );
+
+			if ( data.value ) {
+				expectTypeOf( data.value.CKEditorPremiumFeatures ).toBeNullable();
+			}
+		} );
+
+		it( 'should return non-nullable ckbox entry type if ckbox enabled', async () => {
+			const { data } = useCKEditorCloud( {
+				version: '43.0.0',
+				ckbox: {
+					version: '2.5.1'
+				}
+			} );
+
+			await vi.waitFor( () => {
+				expect( data.value?.CKEditor ).toBeDefined();
+			} );
+
+			if ( data.value ) {
+				expectTypeOf( data.value.CKBox ).not.toBeNullable();
+			}
+		} );
+
+		it( 'should return nullable ckbox entry type if ckbox not configured', async () => {
+			const { data } = useCKEditorCloud( {
+				version: '43.0.0'
+			} );
+
+			await vi.waitFor( () => {
+				expect( data.value?.CKEditor ).toBeDefined();
+			} );
+
+			if ( data.value ) {
+				expectTypeOf( data.value.CKBox ).toBeNullable();
+			}
 		} );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,10 +1195,10 @@
     "@ckeditor/ckeditor5-utils" "42.0.2"
     ckeditor5 "42.0.2"
 
-"@ckeditor/ckeditor5-integrations-common@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-1.0.0.tgz#f2f73509d029398929ee30da3ae23329de5a796a"
-  integrity sha512-HLToIJ7FAtKX0tu9GaGb1d39Kx0i0TFelAj2pQPiwPU/6DLgM5gi+m0WCZub+syruSonmZPONtWrrZZdUoDB/g==
+"@ckeditor/ckeditor5-integrations-common@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.0.0.tgz#09ea8a6a6a3c01f601260a85d9af98ede78644cf"
+  integrity sha512-Gkt7tYVv168voQZFdN4PxVp6M5/ZgzIOrqI6uPRjuk73dYjdLCeotnEXYejE6cxyLi9m2UM2mvhXibOIKVcoPw==
 
 "@ckeditor/ckeditor5-language@42.0.2":
   version "42.0.2"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Improve result type of `useCKEditorCloud` to make `CKEditorPremiumFeatures` and `CKBox` non-nullable when proper configuration is passed.   
Fix: Rename the `languages` configuration property to `translations` in `useCKEditorCloud`.

---

### Additional information

Must be released before testing:  
https://github.com/ckeditor/ckeditor5-integrations-common/pull/25


PRs family:
https://github.com/ckeditor/ckeditor5-react/pull/523

```tsx
const { CKEditorPremiumFeatures } = await loadCKEditorCloud( {
  version: '43.0.0',
  premium: true,
  ckbox: {
    version: '2.5.1'
  }
} );
```

**Before:**

`CKEditorPremiumFeatures` is nullable type.

**After**:

`CKEditorPremiumFeatures` is not nullable type because `premium: true` is passed.
