### PR TITLE
Add missing `console.error` in cloud editor demo

### DIFF
--- a/demos/editor-cdn/App.vue
+++ b/demos/editor-cdn/App.vue
@@ -37,13 +37,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed } from 'vue';
+import { ref, reactive, computed, effect } from 'vue';
 import useCKEditorCloud from '../../src/useCKEditorCloud.js';
 import type { EventInfo, ClassicEditor } from 'https://cdn.ckeditor.com/typings/ckeditor5.d.ts';
 
 // Load CKEditor from the CDN
 const cloud = useCKEditorCloud( {
 	version: '43.0.0'
+} );
+
+effect( () => {
+	if ( cloud.error.value ) {
+		console.error( cloud.error.value );
+	}
 } );
 
 const TestEditor = computed<typeof ClassicEditor | null>( () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Log cloud editor fetching errors in demo if present.