### PR TITLE
Print cloud errors in console if present.

### DIFF
--- a/demos/editor-cdn/App.vue
+++ b/demos/editor-cdn/App.vue
@@ -37,19 +37,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, effect } from 'vue';
+import { ref, reactive, computed } from 'vue';
 import useCKEditorCloud from '../../src/useCKEditorCloud.js';
 import type { EventInfo, ClassicEditor } from 'https://cdn.ckeditor.com/typings/ckeditor5.d.ts';
 
 // Load CKEditor from the CDN
 const cloud = useCKEditorCloud( {
 	version: '43.0.0'
-} );
-
-effect( () => {
-	if ( cloud.error.value ) {
-		console.error( cloud.error.value );
-	}
 } );
 
 const TestEditor = computed<typeof ClassicEditor | null>( () => {

--- a/src/composables/useAsync.ts
+++ b/src/composables/useAsync.ts
@@ -61,6 +61,8 @@ export const useAsync = <R>(
 				data.value = result;
 			}
 		} catch ( err: any ) {
+			console.error( err );
+
 			if ( !shouldDiscardQuery() ) {
 				error.value = err;
 			}

--- a/tests/composables/useAsync.test.ts
+++ b/tests/composables/useAsync.test.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import { it, describe, expect } from 'vitest';
+import { it, vi, describe, expect } from 'vitest';
 import { ref } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 
@@ -40,6 +40,20 @@ describe( 'useAsync', () => {
 		expect( error.value ).toEqual( errorInstance );
 		expect( loading.value ).toBe( false );
 		expect( data.value ).toBe( null );
+	} );
+
+	it( 'should print errors in console if the async function throws an error', async () => {
+		const errorInstance = new Error( 'test' );
+		const consoleSpy = vi.spyOn( console, 'error' );
+
+		useAsync( async () => {
+			throw errorInstance;
+		} );
+
+		await flushPromises();
+
+		expect( consoleSpy ).toHaveBeenCalledWith( errorInstance );
+		consoleSpy.mockRestore();
 	} );
 
 	it( 'should re-run async function on change ref inside async function', async () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feat: Log cloud fetch errors to console.

---

### Additional information

At this moment - nothing is being printed in console when the exception is thrown, so debugging the errors related to the CDN fetching might be time-consuming. I added logger.

Example log:

![obraz](https://github.com/user-attachments/assets/9fcb5065-9395-49b9-86bd-b18f92ddecd5)
