### PR TITLE
Internal: Add missing `typescript-eslint` dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "minimist": "^1.2.5",
     "semver": "^7.0.0",
     "typescript": "~5.4.5",
+    "typescript-eslint": "^8.32.1",
     "vite": "^5.3.1",
     "vitest": "^2.1.9",
     "vue": "^3.4.30",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9461,7 +9461,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript-eslint@^8.32.0:
+typescript-eslint@^8.32.0, typescript-eslint@^8.32.1:
   version "8.32.1"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.32.1.tgz#1784335c781491be528ff84ab666e2f0f7591fd1"
   integrity sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Add missing `typescript-eslint` dev dependency.
