### PR TITLE
Use dynamic imports to fix issues in the release process

### DIFF
--- a/scripts/preparepackages.js
+++ b/scripts/preparepackages.js
@@ -66,10 +66,10 @@ const tasks = new Listr( [
 	},
 	{
 		title: 'Creating the `ckeditor5-vue` package in the release directory.',
-		task: () => {
+		task: async () => {
 			return releaseTools.prepareRepository( {
 				outputDirectory: 'release',
-				rootPackageJson: preparePackageJson()
+				rootPackageJson: await preparePackageJson()
 			} );
 		}
 	},

--- a/scripts/utils/preparepackagejson.js
+++ b/scripts/utils/preparepackagejson.js
@@ -3,9 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-import packageJson from '../../package.json' with { type: 'json' };
+export async function preparePackageJson() {
+	const { default: packageJson } = await import( '../../package.json', { with: { type: 'json' } } );
 
-export function preparePackageJson() {
 	if ( packageJson.engines ) {
 		delete packageJson.engines;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use dynamic imports to fix issues in the release process. Closes #364.

---

### Additional information

**Testing steps**

* I modified the latest changelog version (patch bump).
* `rm -rf release/; yarn release:prepare-packages --branch i/364; cat release/ckeditor5-vue/package.json | grep version`
	```
	yarn run v1.22.19
	$ node ./scripts/preparepackages.js --branch i/364
	✔ Verifying the repository.
	✔ Updating the `#version` field.
	✔ Running build command.
	✔ Creating the `ckeditor5-vue` package in the release directory.
	✔ Cleaning-up.
	✔ Commit & tag.
	Done in 4.70s.
	  "version": "7.3.1",
	```

To clean-up:

```
git tag -d v7.3.1
git reset --hard HEAD~1
```
