### PR TITLE
Run integration tests for latest and LTS editor releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ jobs:
               if [[ -z ${CODECOV_TOKEN} ]]; then
                 echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this community environment."
                 circleci-agent step halt
+                exit 0
               fi
 
               echo "Failing the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is required in this environment."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,13 @@ jobs:
 
             if [[ "<< parameters.ckeditorDistTag >>" != "latest" && -z ${CKEDITOR_LICENSE_KEY} ]];
             then
-              echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this environment."
-              circleci-agent step halt
+              if [[ -z ${CODECOV_TOKEN} ]]; then
+                echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this community environment."
+                circleci-agent step halt
+              fi
+
+              echo "Failing the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is required in this environment."
+              exit 1
             fi
       - run:
           name: Install CKEditor packages for << parameters.ckeditorDistTag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,50 @@ jobs:
                 files: coverage/lcov.info
                 disable_search: true
 
+  tests_integration:
+    docker:
+      - image: cimg/node:24.11.0-browsers
+    parameters:
+      ckeditorDistTag:
+        type: string
+    steps:
+      - checkout
+      - bootstrap_repository_command
+      - browser-tools/install_chrome
+      - run:
+          name: Resolve and deduplicate versions
+          command: |
+            #!/bin/bash
+
+            EDITOR_VERSION_TAG=<< parameters.ckeditorDistTag >>
+            SELECTED_VERSION=$( pnpm view ckeditor5@${EDITOR_VERSION_TAG} version )
+            LATEST_VERSION=$( pnpm view ckeditor5@latest version )
+
+            echo "Resolved ckeditor5@${EDITOR_VERSION_TAG} -> ${SELECTED_VERSION}"
+            echo "Resolved ckeditor5@latest -> ${LATEST_VERSION}"
+
+            if [[ "${EDITOR_VERSION_TAG}" != "latest" && "${SELECTED_VERSION%%.*}" == "${LATEST_VERSION%%.*}" ]];
+            then
+              echo "Skipping duplicated integration run because ${EDITOR_VERSION_TAG} and latest resolve to the same major version."
+              circleci-agent step halt
+            fi
+      - run:
+          name: Verify license key
+          command: |
+            #!/bin/bash
+
+            if [[ "<< parameters.ckeditorDistTag >>" != "latest" && -z ${CKEDITOR_LICENSE_KEY} ]];
+            then
+              echo "Skipping the << parameters.ckeditorDistTag >> integration run because CKEDITOR_LICENSE_KEY is not available in this environment."
+              circleci-agent step halt
+            fi
+      - run:
+          name: Install CKEditor packages for << parameters.ckeditorDistTag >>
+          command: pnpm add -D ckeditor5@<< parameters.ckeditorDistTag >> ckeditor5-premium-features@<< parameters.ckeditorDistTag >>
+      - run:
+          name: Run integration tests for << parameters.ckeditorDistTag >>
+          command: pnpm run test:integration
+
   release_prepare:
     docker:
       - image: cimg/node:24.11.0
@@ -251,10 +295,18 @@ workflows:
         - equal: [ false, << pipeline.parameters.isRelease >> ]
     jobs:
       - validate_and_tests
+      - tests_integration:
+          matrix:
+            alias: tests_integration_matrix
+            parameters:
+              ckeditorDistTag: &integration_editor_version_tags
+                - latest
+                - lts-v47
       - release_prepare
       - trigger_release_process:
           requires:
             - validate_and_tests
+            - tests_integration_matrix
             - release_prepare
           filters:
             branches:
@@ -285,6 +337,10 @@ workflows:
         - equal: [ false, << pipeline.parameters.isRelease >> ]
     jobs:
       - validate_and_tests
+      - tests_integration:
+          matrix:
+            parameters:
+              ckeditorDistTag: *integration_editor_version_tags
       - notify_ci_failure:
           hideAuthor: "true"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
             then
               echo "Skipping duplicated integration run because ${EDITOR_VERSION_TAG} and latest resolve to the same major version."
               circleci-agent step halt
+              exit 0
             fi
       - run:
           name: Verify license key

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# CKEditor 5 demo and test environment variables
+#
+# Copy this file to `.env` and fill in your actual values.
+# NEVER commit `.env` to version control.
+
+# Your CKEditor 5 commercial license key.
+# Obtain it from: https://portal.ckeditor.com
+CKEDITOR_LICENSE_KEY=
+
+# Cloud Services token endpoint URL.
+# This is the URL of YOUR token endpoint that returns a JWT signed with
+# your Cloud Services secret key. The URL is called by the editor on
+# every session start and refreshed periodically.
+CKEDITOR_TOKEN_URL=
+
+# Cloud Services WebSocket URL.
+# Provided by CKEditor Cloud Services or your self-hosted CS instance.
+CKEDITOR_WEBSOCKET_URL=
+
+# Optional Cloud Services file upload URL.
+# This is the URL of YOUR file upload endpoint that accepts uploaded files.
+CKEDITOR_UPLOAD_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 coverage/
 dist/
+.env
 .idea
 .tmp
 /release/

--- a/README.md
+++ b/README.md
@@ -44,10 +44,29 @@ pnpm run dev
 
 ### Executing tests
 
-To test the editor integration against a set of automated tests, run the following command:
+To run the full automated test suite, use:
 
 ```bash
 pnpm run test
+```
+
+To run only the real-editor integration test used by the CI version matrix, use:
+
+```bash
+pnpm run test:integration
+```
+
+This command runs against the `ckeditor5` packages currently installed in `node_modules`.
+After a regular `pnpm install`, that means the default dependency versions from `package.json`, not the LTS version from the CI matrix.
+
+To reproduce an LTS matrix run locally, copy `.env.example` to `.env`, fill in `CKEDITOR_LICENSE_KEY`, and then install the matching `lts-v*` packages:
+
+```bash
+cp .env.example .env
+# fill in CKEDITOR_LICENSE_KEY in .env
+
+pnpm add -D ckeditor5@lts-v47 ckeditor5-premium-features@lts-v47
+pnpm run test:integration
 ```
 
 If you want to run the tests in watch mode, use the following command:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ After cloning this repository, install necessary dependencies:
 pnpm install
 ```
 
+If you need to run tests or demos with a commercial license, copy `.env.example` to `.env` and fill in the required `CKEDITOR_*` variables.
+Keep `.env` local only. In CI, provide the same value via the `CKEDITOR_LICENSE_KEY` environment variable.
+
 ### Running the development server
 
 To manually test the editor integration, you can start the development server using one of the commands below:

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build && vue-tsc --emitDeclarationOnly",
     "test": "vitest run --coverage",
+    "test:integration": "vitest run tests/plugin/integration.test.ts",
     "test:watch": "vitest --ui --watch",
     "test:check:types": "tsc --noEmit -p ./tests/tsconfig.json",
     "test:scripts": "vitest --config ./scripts-tests/vitest.config.mjs --run",

--- a/tests/plugin/integration.test.ts
+++ b/tests/plugin/integration.test.ts
@@ -10,6 +10,8 @@ import { CkeditorPlugin } from '../../src/plugin.js';
 
 describe( 'CKEditor plugin', () => {
 	it( 'should work with an actual editor build', async () => {
+		const consoleErrorSpy = vi.spyOn( console, 'error' );
+
 		class TestEditor extends ClassicEditor {
 			public static builtinPlugins = [
 				Essentials,
@@ -54,6 +56,15 @@ describe( 'CKEditor plugin', () => {
 		expect( instance ).toBeInstanceOf( TestEditor );
 		expect( instance!.getData() ).toBe( '<p>foo</p>' );
 
+		const ckeditorErrors = consoleErrorSpy.mock.calls.filter(
+			args => args.some( arg => String( arg ).includes( 'CKEditorError' ) )
+		);
+
+		const errorMessage = 'CKEditorError was logged — check if the license key is valid for the installed CKEditor packages.';
+
+		expect( ckeditorErrors, errorMessage ).toHaveLength( 0 );
+
+		consoleErrorSpy.mockRestore();
 		wrapper.unmount();
 	} );
 } );

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -3,4 +3,21 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+/// <reference types="vite/client" />
+
 declare const __VUE_INTEGRATION_VERSION__: string;
+
+interface ImportMetaEnv {
+	readonly CKEDITOR_LICENSE_KEY: string;
+	readonly CKEDITOR_TOKEN_URL: string;
+	readonly CKEDITOR_WEBSOCKET_URL: string;
+	readonly CKEDITOR_UPLOAD_URL: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}
+
+interface Window {
+	CKEDITOR_GLOBAL_LICENSE_KEY?: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig( {
 		vue()
 	],
 
+	envPrefix: 'CKEDITOR_',
+
 	build: {
 		minify: false,
 		sourcemap: true,

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -3,4 +3,4 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-window.CKEDITOR_GLOBAL_LICENSE_KEY = 'GPL';
+window.CKEDITOR_GLOBAL_LICENSE_KEY = import.meta.env.CKEDITOR_LICENSE_KEY || 'GPL';


### PR DESCRIPTION
### 🚀 Summary

* Add a dedicated `tests_integration` CircleCI matrix for `latest` and `lts-v47`, and skip the duplicate LTS run when both tags resolve to the same major.
* Load `CKEDITOR_*` values from `.env`/CI so browser-mode Vitest can use a commercial license key for the LTS path, with `.env.example` and local setup docs matching the React integration.
* Add a focused `test:integration` script and document how to reproduce the matrix runs locally.

---

### 📌 Related issues

* Closes #409

---

### 💡 Additional information

* Internal-only CI, test, and docs changes, so no changelog entry is needed.
* Verified with `pnpm run test:integration` and `pnpm run test:check:types`.