### PR TITLE
Apply the ratified dependency policy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ commands:
           command: sudo corepack disable
       - run:
           name: Install pnpm
-          command: sudo npm i -g pnpm@^11
+          command: sudo npm i -g pnpm@11.14.0
       - run:
           name: Install dependencies
-          command: pnpm install
+          command: pnpm install --frozen-lockfile
 
   install_ssh_keys_command:
     description: "Install SSH keys"
@@ -47,7 +47,7 @@ commands:
     steps:
       - run:
           name: Install npm with CircleCI OIDC support
-          command: sudo npm i -g npm@^11.11.0
+          command: sudo npm i -g npm@11.19.1
       - run:
           name: Get npm OIDC token
           command: |

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Dependency and CI files are owned by the platform team - see ckeditor5-internal#4697.
+/.github/                            @ckeditor/ckeditor-5-platform
+/.circleci/                          @ckeditor/ckeditor-5-platform
+/package.json                        @ckeditor/ckeditor-5-platform
+/pnpm-lock.yaml                      @ckeditor/ckeditor-5-platform
+/pnpm-workspace.yaml                 @ckeditor/ckeditor-5-platform

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,11 +13,21 @@ overrides:
 
 minimumReleaseAge: 4320 # 3 days
 minimumReleaseAgeExclude:
+  # Company-owned scopes - every release comes from our own pipelines.
   - '@ckeditor/*'
   - '@cksource/*'
-  - '*ckeditor5*'
+  # Company-owned unscoped names, listed one by one. The `*ckeditor5*` glob used here before
+  # also matched foreign packages with `ckeditor5` in the name - see ckeditor5-internal#4665.
+  - 'ckeditor5' # Owned by the `ckeditor` npm account.
+  - 'ckeditor5-premium-features' # Owned by the `ckeditor` npm account.
+  - 'ckeditor5-collaboration' # Owned by the `ckeditor` npm account.
+  - 'eslint-config-ckeditor5' # Published from `ckeditor/ckeditor5-linters-config`.
+  - 'eslint-plugin-ckeditor5-rules' # Published from `ckeditor/ckeditor5-linters-config`.
 
 shellEmulator: true
 shamefullyHoist: true
 preferFrozenLockfile: true
 verifyDepsBeforeRun: false
+# Only registry tarballs may enter the tree as subdependencies. Direct git/tarball
+# dependencies stay allowed - see ckeditor/ckeditor5#20216.
+blockExoticSubdeps: true


### PR DESCRIPTION
### 🚀 Summary

Applies the ratified dependency policy in this repository:

* pnpm is pinned to `11.14.0` everywhere it is installed. It was a floating range before, which left the tool that enforces the cooldown and the build allowlist as the least pinned thing we have.
* Every automated install now says `--frozen-lockfile`, instead of relying on pnpm switching it on by itself once it notices CI.
* The `*ckeditor5*` cooldown exclusion is replaced by the five unscoped names we own. The glob matched *any* package with `ckeditor5` in the name, including someone else's, and an excluded name skips the cooldown completely.
* The remaining global installs name exact versions.
* A CODEOWNERS file is added - this repository had none, so nothing required a platform-team review of its lockfile or CI. It covers the dependency and CI paths the policy names, not the source directories.
* `blockExoticSubdeps: true` is added, so only registry tarballs can enter the tree as subdependencies.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4697.
* Policy and per-repository findings: https://github.com/ckeditor/ckeditor5-internal/issues/4665.
* `blockExoticSubdeps`: https://github.com/ckeditor/ckeditor5/issues/20216.

---

### 💡 Additional information

Checked with `pnpm install --frozen-lockfile --lockfile-only` on pnpm 11.14.0: the lockfile passes (927 entries), so `blockExoticSubdeps` does not reject anything in the tree today. The CircleCI jobs themselves were not run, so CI here is the real check.

Internal only (CI and dependency settings), so no changelog entry.
